### PR TITLE
Fix login error and restrict tenant creation

### DIFF
--- a/src/Client/Temple.Web/src/pages/App.tsx
+++ b/src/Client/Temple.Web/src/pages/App.tsx
@@ -1,6 +1,7 @@
 import { Routes, Route, Link } from 'react-router-dom';
 import Tenants from './Tenants';
 import Home from './Home';
+import Login from './Login';
 
 export default function App() {
   return (
@@ -9,11 +10,13 @@ export default function App() {
       <nav style={{ display: 'flex', gap: 12 }}>
         <Link to="/">Home</Link>
         <Link to="/tenants">Tenants</Link>
+        <Link to="/login">Login</Link>
         <a href="/swagger" target="_blank" rel="noreferrer">Swagger</a>
       </nav>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/tenants" element={<Tenants />} />
+        <Route path="/login" element={<Login />} />
       </Routes>
     </div>
   );

--- a/src/Client/Temple.Web/src/pages/Login.tsx
+++ b/src/Client/Temple.Web/src/pages/Login.tsx
@@ -1,0 +1,47 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+
+export default function Login() {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const navigate = useNavigate();
+
+  async function submit(e: React.FormEvent) {
+    e.preventDefault();
+    setError(null);
+    try {
+      const resp = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ email, password })
+      });
+      if (!resp.ok) throw new Error(await resp.text());
+      const data = await resp.json();
+      localStorage.setItem('token', data.accessToken);
+      navigate('/tenants');
+    } catch (e: any) {
+      setError(e.message);
+    }
+  }
+
+  return (
+    <form onSubmit={submit}>
+      <h2>Login</h2>
+      <div>
+        <label>
+          Email
+          <input value={email} onChange={e => setEmail(e.target.value)} />
+        </label>
+      </div>
+      <div>
+        <label>
+          Password
+          <input type="password" value={password} onChange={e => setPassword(e.target.value)} />
+        </label>
+      </div>
+      <button type="submit">Login</button>
+      {error && <p style={{ color: 'red' }}>{error}</p>}
+    </form>
+  );
+}

--- a/src/Client/Temple.Web/src/pages/Tenants.tsx
+++ b/src/Client/Temple.Web/src/pages/Tenants.tsx
@@ -11,6 +11,7 @@ export default function Tenants() {
   const [tenants, setTenants] = useState<Tenant[]>([]);
   const [creating, setCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const token = localStorage.getItem('token');
 
   useEffect(() => {
     // No list endpoint yet; placeholder
@@ -22,7 +23,7 @@ export default function Tenants() {
     try {
       const resp = await fetch('/api/tenants', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: { 'Content-Type': 'application/json', ...(token ? { 'Authorization': `Bearer ${token}` } : {}) },
         body: JSON.stringify({ name: `UAT Tenant ${Date.now()}` })
       });
       if (!resp.ok) throw new Error(await resp.text());
@@ -37,8 +38,9 @@ export default function Tenants() {
 
   return (
     <div>
-      <h2>Tenants</h2>
-      <button disabled={creating} onClick={createTenant}>{creating ? 'Creating...' : 'Create Tenant'}</button>
+      {token && (
+        <button disabled={creating} onClick={createTenant}>{creating ? 'Creating...' : 'Create Tenant'}</button>
+      )}
       {error && <p style={{ color: 'red' }}>{error}</p>}
       <ul>
         {tenants.map(t => <li key={t.id}>{t.name} ({t.slug})</li>)}


### PR DESCRIPTION
## Summary
- prevent null login requests from causing server errors
- require auth for tenant creation
- add login page and hide create tenant button unless logged in

## Testing
- `dotnet test`
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: ESLint couldn't find an eslint.config.(js|mjs|cjs) file)

------
https://chatgpt.com/codex/tasks/task_e_68959ad16490832dbd35af869910e7d4